### PR TITLE
Made custom share url optional

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,3 @@
+{
+  "enableCustomUrl": true
+}

--- a/index.js
+++ b/index.js
@@ -7,8 +7,14 @@ const openbeelden = require('./partials/openbeelden')
 const cronJobs = require('./partials/cronJobs')
 const cron = require('node-cron')
 const db = require('./partials/db')
+const config = require('./config.json')
 
-db.init()
+if (config.enableCustomUrl) {
+  db.init()
+  app
+    .post('/share', share)
+    .get('/share/:id', shareUrl)
+}
 
 app
   .set('view engine', 'ejs')
@@ -21,8 +27,7 @@ app
   .get('/random/:id', sendRandom)
   .get('/search/:id', search)
   .get('/detail/:id', detail)
-  .post('/share', share)
-  .get('/share/:id', shareUrl)
+
   .get('/ob-video/:id', sendMetadata)
   .get('/filter/:id', sendFiltered)
   .get('/related/:id/:amount', sendRelated)


### PR DESCRIPTION
If `enableCustomUrl` in `config.json` is set to false, a database is no longer required and mysql won't log errors and try to reconnect.